### PR TITLE
Update crud.rs：忽略为空的 column

### DIFF
--- a/src/crud.rs
+++ b/src/crud.rs
@@ -117,6 +117,9 @@ pub trait CRUDTable: Send + Sync + Serialize + DeserializeOwned {
         for column in columns {
             let column = crate::utils::string_util::un_packing_string(column);
             let v = map.get(column).unwrap_or(&serde_json::Value::Null);
+            if v == &serde_json::Value::Null {
+                continue;
+            }
             //cast convert
             column_sql = column_sql + column + ",";
             let mut data = String::new();


### PR DESCRIPTION
```sql
create or replace function upd_timestamp() returns trigger as
$$
begin
    new.updated_at = current_timestamp;
    return new;
end
$$
language plpgsql;
```
```sql
create table users(
    id         bigint                   not null primary key,
    name       varchar(255)             not null,
    created_at timestamp default now()  not null,
    updated_at timestamp default now()  not null
);
create trigger users_timestamp before update on users for each row execute procedure upd_timestamp();
```
1、Pg数据库 created_at、updated_at，使用trigger提供默认值。则 insert 语句中，不能再 insert into (created_at) values (null)，而应该忽略该字段。