### PR TITLE
Make PartialOrd impls more robust by derererencing explicitly

### DIFF
--- a/rbatis-codegen/src/ops_cmp.rs
+++ b/rbatis-codegen/src/ops_cmp.rs
@@ -272,13 +272,13 @@ impl PartialOrd<&str> for &String {
 
 impl PartialOrd<&&str> for &String {
     fn op_partial_cmp(&self, rhs: &&&str) -> Option<Ordering> {
-        self.as_str().partial_cmp(rhs)
+        self.as_str().partial_cmp(*rhs)
     }
 }
 
 impl PartialOrd<&&&str> for &String {
     fn op_partial_cmp(&self, rhs: &&&&str) -> Option<Ordering> {
-        self.as_str().partial_cmp(rhs)
+        self.as_str().partial_cmp(**rhs)
     }
 }
 


### PR DESCRIPTION
Add the appropriate number of `*`s when dereferencing, to avoid counting
on implicit dereferences. The implicit dereferences can fail with
inference issues if more impls become available.
