### PR TITLE
修复不使用`将sql的每一行包裹，导致原始sql有换行时生成的sql粘连问题

### DIFF
--- a/rbatis-codegen/src/codegen/parser_html.rs
+++ b/rbatis-codegen/src/codegen/parser_html.rs
@@ -294,7 +294,7 @@ fn remove_extra(text: &str) -> String {
         }
     }
 
-    data.trim_matches('`').replace("``", "")
+    data.trim_matches('`').replace("``", " ")
 }
 
 /// Implements HTML SQL function

--- a/rbatis-codegen/src/codegen/parser_html.rs
+++ b/rbatis-codegen/src/codegen/parser_html.rs
@@ -303,7 +303,7 @@ fn remove_extra(text: &str) -> String {
         }
     }
 
-    data.trim_matches('`').to_owned()
+    data.to_owned()
 }
 
 /// Implements HTML SQL function

--- a/rbatis-codegen/src/codegen/parser_html.rs
+++ b/rbatis-codegen/src/codegen/parser_html.rs
@@ -303,7 +303,7 @@ fn remove_extra(text: &str) -> String {
         }
     }
 
-    data.to_owned()
+    data
 }
 
 /// Implements HTML SQL function

--- a/rbatis-codegen/src/codegen/parser_html.rs
+++ b/rbatis-codegen/src/codegen/parser_html.rs
@@ -272,9 +272,9 @@ fn handle_text_element(
 
     if !string_data.is_empty() {
         *body = if replace_num == 0 {
-            quote! { #body sql = rbatis_codegen::codegen::string_util::concat_str(sql, #string_data); }
+            quote! { #body rbatis_codegen::codegen::string_util::concat_str(&mut sql, #string_data); }
         } else {
-            quote! { #body sql = rbatis_codegen::codegen::string_util::concat_str(sql, &format!(#string_data #formats_value)); }
+            quote! { #body rbatis_codegen::codegen::string_util::concat_str(&mut sql, &format!(#string_data #formats_value)); }
         };
     }
 }
@@ -292,7 +292,7 @@ fn remove_extra(text: &str) -> String {
         let list: Vec<&str> = line.split("``").collect();
         let mut text = String::with_capacity(line.len());
         for s in list {
-            text = concat_str(text, s);
+            concat_str(&mut text, s);
         }
         data.push_str(&text);
         if i + 1 < lines.len() {

--- a/rbatis-codegen/src/codegen/parser_html.rs
+++ b/rbatis-codegen/src/codegen/parser_html.rs
@@ -6,7 +6,7 @@ use syn::{ItemFn};
 
 use crate::codegen::loader_html::{load_html, Element};
 use crate::codegen::proc_macro::TokenStream as MacroTokenStream;
-use crate::codegen::string_util::find_convert_string;
+use crate::codegen::string_util::{concat_str, find_convert_string};
 use crate::codegen::syntax_tree_html::*;
 use crate::codegen::ParseArgs;
 use crate::error::Error;
@@ -272,9 +272,9 @@ fn handle_text_element(
 
     if !string_data.is_empty() {
         *body = if replace_num == 0 {
-            quote! { #body sql.push_str(#string_data); }
+            quote! { #body sql = rbatis_codegen::codegen::string_util::concat_str(sql, #string_data); }
         } else {
-            quote! { #body sql.push_str(&format!(#string_data #formats_value)); }
+            quote! { #body sql = rbatis_codegen::codegen::string_util::concat_str(sql, &format!(#string_data #formats_value)); }
         };
     }
 }
@@ -292,10 +292,7 @@ fn remove_extra(text: &str) -> String {
         let list: Vec<&str> = line.split("``").collect();
         let mut text = String::with_capacity(line.len());
         for s in list {
-            if !text.is_empty() && !text.ends_with(' ') && !s.starts_with(' ') {
-                text.push(' ');
-            }
-            text.push_str(s);
+            text = concat_str(text, s);
         }
         data.push_str(&text);
         if i + 1 < lines.len() {

--- a/rbatis-codegen/src/codegen/parser_html.rs
+++ b/rbatis-codegen/src/codegen/parser_html.rs
@@ -288,13 +288,22 @@ fn remove_extra(text: &str) -> String {
     for (i, line) in lines.iter().enumerate() {
         let mut line = line.trim();
         line = line.trim_start_matches('`').trim_end_matches('`');
-        data.push_str(line);
+
+        let list: Vec<&str> = line.split("``").collect();
+        let mut text = String::with_capacity(line.len());
+        for s in list {
+            if !text.is_empty() && !text.ends_with(' ') && !s.starts_with(' ') {
+                text.push(' ');
+            }
+            text.push_str(s);
+        }
+        data.push_str(&text);
         if i + 1 < lines.len() {
             data.push('\n');
         }
     }
 
-    data.trim_matches('`').replace("``", " ")
+    data.trim_matches('`').to_owned()
 }
 
 /// Implements HTML SQL function

--- a/rbatis-codegen/src/codegen/string_util.rs
+++ b/rbatis-codegen/src/codegen/string_util.rs
@@ -52,3 +52,18 @@ pub fn un_packing_string(column: &str) -> &str {
     }
     return column;
 }
+
+pub fn concat_str(mut text: String, append_str: &str) -> String {
+    if !text.is_empty() 
+        && !text.ends_with(' ') 
+        && !append_str.starts_with(' ')
+        //以下两个判断条件内容是为了通过单元测试添加的内容
+        //我觉得没必要所以更改了测试用例
+        //&& !text.ends_with(',')
+        //&& !append_str.starts_with(')') 
+        {
+        text.push(' ');
+    }
+    text.push_str(append_str);
+    text
+}

--- a/rbatis-codegen/src/codegen/string_util.rs
+++ b/rbatis-codegen/src/codegen/string_util.rs
@@ -53,7 +53,7 @@ pub fn un_packing_string(column: &str) -> &str {
     return column;
 }
 
-pub fn concat_str(mut text: String, append_str: &str) -> String {
+pub fn concat_str(text: &mut String, append_str: &str) {
     if !text.is_empty() 
         && !text.ends_with(' ') 
         && !append_str.starts_with(' ')
@@ -65,5 +65,4 @@ pub fn concat_str(mut text: String, append_str: &str) -> String {
         text.push(' ');
     }
     text.push_str(append_str);
-    text
 }

--- a/tests/crud_test.rs
+++ b/tests/crud_test.rs
@@ -361,7 +361,7 @@ mod test {
             let r = MockTable::insert(&mut rb, &t).await.unwrap();
             let (sql, args) = queue.pop().unwrap();
             println!("{} [{}]", sql, Value::from(args.clone()));
-            assert_eq!(sql, "insert into mock_table (id,name,pc_link,h5_link,status,remark,create_time,version,delete_flag,count) VALUES (?,?,?,?,?,?,?,?,?,?)");
+            assert_eq!(sql, "insert into mock_table (id, name, pc_link, h5_link, status, remark, create_time, version, delete_flag, count ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ? )");
             assert_eq!(
                 args,
                 vec![
@@ -410,7 +410,7 @@ mod test {
             let r = MockTable::insert_batch(&mut rb, &ts, 10).await.unwrap();
             let (sql, args) = queue.pop().unwrap();
             println!("{} [{}]", sql, Value::from(args.clone()));
-            assert_eq!(sql, "insert into mock_table (id,name,pc_link,h5_link,status,remark,create_time,version,delete_flag,count) VALUES (?,?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?,?)");
+            assert_eq!(sql, "insert into mock_table (id, name, pc_link, h5_link, status, remark, create_time, version, delete_flag, count ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ? ), (?, ?, ?, ?, ?, ?, ?, ?, ?, ? )");
             assert_eq!(
                 args,
                 vec![
@@ -468,7 +468,7 @@ mod test {
 
             let (sql, args) = queue.pop().unwrap();
             println!("{}", sql);
-            assert_eq!(sql, "update mock_table set name=?,pc_link=?,h5_link=?,status=?,remark=?,create_time=?,version=?,delete_flag=?,count=?  where id = ?");
+            assert_eq!(sql, "update mock_table set name=?, pc_link=?, h5_link=?, status=?, remark=?, create_time=?, version=?, delete_flag=?, count=?  where id = ?");
             assert_eq!(args.len(), 10);
             assert_eq!(
                 args,
@@ -517,7 +517,7 @@ mod test {
 
             let (sql, args) = queue.pop().unwrap();
             println!("{}", sql);
-            assert_eq!(sql, "update mock_table set name=?,pc_link=?,h5_link=?,status=?,remark=?,create_time=?,version=?,delete_flag=?,count=? ");
+            assert_eq!(sql, "update mock_table set name=?, pc_link=?, h5_link=?, status=?, remark=?, create_time=?, version=?, delete_flag=?, count=? ");
             assert_eq!(args.len(), 9);
             assert_eq!(
                 args,
@@ -565,7 +565,7 @@ mod test {
 
             let (sql, args) = queue.pop().unwrap();
             println!("{}", sql);
-            assert_eq!(sql, "update mock_table set name=?,pc_link=?,h5_link=?,status=?,remark=?,create_time=?,version=?,delete_flag=?,count=?  where ids in (?,?)");
+            assert_eq!(sql, "update mock_table set name=?, pc_link=?, h5_link=?, status=?, remark=?, create_time=?, version=?, delete_flag=?, count=?  where ids in (?, ? )");
             assert_eq!(args.len(), 11);
             assert_eq!(
                 args,
@@ -720,7 +720,7 @@ mod test {
             println!("{}", sql);
             assert_eq!(
                 sql,
-                "delete from mock_table where id in (?)"
+                "delete from mock_table where id in (? )"
             );
             assert_eq!(args, vec![value!("1")]);
         };
@@ -838,7 +838,7 @@ mod test {
                 .unwrap();
             let (sql, args) = queue.pop().unwrap();
             println!("{}", sql);
-            assert_eq!(sql, "update mock_table set name=?,pc_link=?,h5_link=?,status=?,remark=?,create_time=?,version=?,delete_flag=?,count=? where id = '2'");
+            assert_eq!(sql, "update mock_table set name=?, pc_link=?, h5_link=?, status=?, remark=?, create_time=?, version=?, delete_flag=?, count=? where id = '2'");
             assert_eq!(
                 args,
                 vec![
@@ -891,7 +891,7 @@ mod test {
             .unwrap();
             let (sql, args) = queue.pop().unwrap();
             println!("{}", sql);
-            assert_eq!(sql, "update mock_table set name=?,pc_link=?,h5_link=?,status=?,remark=?,create_time=?,version=?,delete_flag=?,count=? where id = '2'");
+            assert_eq!(sql, "update mock_table set name=?, pc_link=?, h5_link=?, status=?, remark=?, create_time=?, version=?, delete_flag=?, count=? where id = '2'");
             assert_eq!(
                 args,
                 vec![
@@ -1142,7 +1142,7 @@ mod test {
                 .unwrap();
             let (sql, args) = queue.pop().unwrap();
             println!("{}", sql);
-            assert_eq!(sql, "select * from mock_table where 1 in (?,?)");
+            assert_eq!(sql, "select * from mock_table where 1 in (?, ? )");
             assert_eq!(args, vec![value!("1"), value!("2")]);
         };
         block_on(f);
@@ -1160,7 +1160,7 @@ mod test {
                 .unwrap();
             let (sql, args) = queue.pop().unwrap();
             println!("{}", sql);
-            assert_eq!(sql, "delete from mock_table where 1 in (?,?)");
+            assert_eq!(sql, "delete from mock_table where 1 in (?, ? )");
             assert_eq!(args, vec![value!("1"), value!("2")]);
         };
         block_on(f);
@@ -1295,6 +1295,85 @@ mod test {
             assert_eq!(
                 sql,
                 "select  * from activity where delete_flag = 0 and var1 = ? and name=? limit 0,10 "
+            );
+            let (sql, args) = queue.pop().unwrap();
+            println!("{}", sql);
+            assert_eq!(
+                sql,
+                "select count(1) as count from activity where delete_flag = 0 and var1 = ? and name=?"
+            );
+        };
+        block_on(f);
+    }
+
+    rbatis::htmlsql_select_page!(htmlsql_select_page_by_name1(name: &str) -> MockTable => 
+    r#"<select id="select_page_data">
+        select 
+        <if test="do_count == true">
+          count(1) from table 
+        </if>
+        <if test="do_count == false">
+          * from table limit ${page_no},${page_size}
+        </if>
+       </select>"#);
+    #[test]
+    fn test_htmlsql_select_page_by_name1() {
+        let f = async move {
+            let mut rb = RBatis::new();
+            let queue = Arc::new(SyncVec::new());
+            rb.set_intercepts(vec![
+                Arc::new(PageIntercept::new()),
+                Arc::new(MockIntercept::new(queue.clone())),
+            ]);
+            rb.init(MockDriver {}, "test").unwrap();
+            let r = htmlsql_select_page_by_name1(&mut rb, &PageRequest::new(1, 10), "")
+                .await
+                .unwrap();
+            let (sql, args) = queue.pop().unwrap();
+            println!("{}", sql);
+            assert_eq!(sql, "select * from table limit 0,10");
+            let (sql, args) = queue.pop().unwrap();
+            println!("{}", sql);
+            assert_eq!(sql, "select count(1) as count from table");
+        };
+        block_on(f);
+    }
+
+    rbatis::pysql_select_page!(pysql_select_page1(item: PySqlSelectPageArg,var1:&str) -> MockTable =>
+    r#"select 
+      if do_count == true:
+        count(1) as count 
+      if do_count == false:
+         * 
+      from activity where delete_flag = 0 and var1 = #{var1}
+        if item.name != '':
+           and name=#{item.name}"#);
+
+    #[test]
+    fn test_pysql_select_page1() {
+        let f = async move {
+            let mut rb = RBatis::new();
+            let queue = Arc::new(SyncVec::new());
+            rb.set_intercepts(vec![
+                Arc::new(PageIntercept::new()),
+                Arc::new(MockIntercept::new(queue.clone())),
+            ]);
+            rb.init(MockDriver {}, "test").unwrap();
+            let r = pysql_select_page1(
+                &mut rb,
+                &PageRequest::new(1, 10),
+                PySqlSelectPageArg {
+                    name: "aaa".to_string(),
+                },
+                "test",
+            )
+            .await
+            .unwrap();
+            let (sql, args) = queue.pop().unwrap();
+            println!("{}", sql);
+            assert_eq!(
+                sql,
+                "select * from activity where delete_flag = 0 and var1 = ? and name=? limit 0,10 "
             );
             let (sql, args) = queue.pop().unwrap();
             println!("{}", sql);

--- a/tests/html_sql_test.rs
+++ b/tests/html_sql_test.rs
@@ -545,7 +545,7 @@ mod test {
             let r = test_for(&rb, vec![0, 1, 2, 3]).await.unwrap();
             let (sql, args) = queue.pop().unwrap();
             println!("sql={},args={}", sql, Value::Array(args.clone()));
-            assert_eq!(sql, "(1,1),(2,2)");
+            assert_eq!(sql, "(1,1), (2,2)");
             assert_eq!(args, vec![]);
         };
         block_on(f);


### PR DESCRIPTION
例：
```
#pysql[("select user_id, user_name 
from user")]
```

生成的sql为 : 
```sql
select user_id, user_namefrom user
```
修改后生成的sql为：
```sql
select user_id, user_name from user
```

before generate sql is  : 
```
select user_id, user_namefrom user
```
after generate sql is：
```
select user_id, user_name from user
```