### PR TITLE
feat: SQL 单行注释的末尾添加换行符

### DIFF
--- a/rbatis-codegen/src/codegen/string_util.rs
+++ b/rbatis-codegen/src/codegen/string_util.rs
@@ -53,26 +53,67 @@ pub fn un_packing_string(column: &str) -> &str {
     return column;
 }
 
+fn has_single_line_comment(text: &str) -> bool {
+    if text.trim_ascii().is_empty() {
+        return false;
+    }
+    let text = text
+        .rsplit_once('\n')
+        .map(|(_, after)| after)
+        .unwrap_or(text);
+
+    // `--` single-line comment style
+    if text.contains("--") {
+        return true;
+    }
+
+    // MySQL `#` single-line comment style
+    let bytes = text.as_bytes();
+    for i in 0..bytes.len() {
+        if bytes[i] == b'#' {
+            // not match `#{...}`
+            if i + 1 >= bytes.len() || bytes[i + 1] != b'{' {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Efficiently concatenates SQL fragments with automatic space insertion.
 /// Optimized for hot path in SQL code generation.
 #[inline(always)]
 pub fn concat_str(text: &mut String, append_str: &str) {
+    if append_str.is_empty() {
+        return;
+    }
+    // Append a linefeed at the end of a single-line comment
+    let need_ln = !append_str.ends_with('\n') && has_single_line_comment(append_str);
+
     // Fast path: empty text - just push (no space needed)
     if text.is_empty() {
+        let len = append_str.len() + if need_ln { 1 } else { 0 };
+        text.reserve(len);
         text.push_str(append_str);
+        if need_ln {
+            text.push('\n');
+        }
         return;
     }
 
     // Check if we need to add a space between fragments
     // Space is added when: text doesn't end with space AND append_str doesn't start with space
-    let need_space = !text.ends_with(' ') && !append_str.starts_with(' ');
+    let pat = &[' ', '\t', '\n'];
+    let need_space = !text.ends_with(pat) && !append_str.starts_with(pat);
 
     // Reserve capacity to reduce reallocations
+    let len = append_str.len() + if need_space { 1 } else { 0 } + if need_ln { 1 } else { 0 };
+    text.reserve(len);
     if need_space {
-        text.reserve(1 + append_str.len());
         text.push(' ');
-        text.push_str(append_str);
-    } else {
-        text.push_str(append_str);
+    }
+    text.push_str(append_str);
+    if need_ln {
+        text.push('\n');
     }
 }


### PR DESCRIPTION
支持 `--` 和 `#` 风格的SQL单行注释，避免拼接字符串时因sql单行注释缺少必要换行符导致的意外

```xml
<select id="select_by_condition">
      select * from biz_activity
      <where>
       <if test="a">
              and name like #{name}
              -- sql comment 1 
          </if>
          <if test="name != ''">
              and name like #{name}  -- sql comment 2
          </if>
          <if test="dt >= '2009-12-12 00:00:00'">
              and create_time < #{dt}
          </if>
          <choose>
              <when test="true">
                  and id != '-1'
              </when>
              <otherwise>and id != -2</otherwise>
          </choose>
          and  -- sql comment 3
          <trim prefixOverrides=" and">
              and name != ''
          </trim>
      </where>
</select>
```